### PR TITLE
Added case insensitive boolean filter for special coverage flags

### DIFF
--- a/bulbs/campaigns/models.py
+++ b/bulbs/campaigns/models.py
@@ -20,7 +20,6 @@ class Campaign(Indexable):
     class Mapping:
         sponsor_logo = ElasticsearchImageField()
 
-
     @property
     def pixel_dict(self):
         data = {}
@@ -32,8 +31,9 @@ class Campaign(Indexable):
 class CampaignPixel(models.Model):
     """Right now, there are two types of pixels, "Listing" and "Detail". The
     intention here is that the "Listing" pixel is fired anywhere a sponsor's
-    logo shows up on a listing page, or a sidebar. The "Detail" pixel is to 
+    logo shows up on a listing page, or a sidebar. The "Detail" pixel is to
     be fired only when viewing a piece of content connected to that campaign"""
+
     LISTING = 0
     DETAIL = 1
     PIXEL_TYPES = (

--- a/bulbs/campaigns/views.py
+++ b/bulbs/campaigns/views.py
@@ -1,4 +1,5 @@
-from django_filters import DateTimeFilter, FilterSet
+from datetime import datetime
+
 from rest_framework import routers, viewsets, filters
 from rest_framework.permissions import IsAdminUser
 
@@ -6,26 +7,52 @@ from .models import Campaign
 from .serializers import CampaignSerializer
 
 
-class CampaignFilter(FilterSet):
-    start_date = DateTimeFilter(lookup_type="lte")
-    end_date = DateTimeFilter(lookup_type="gt")
+class CampaignActiveFilter(filters.BaseFilterBackend):
+    """Checks for a value for 'active' in query parameters, filters from this
+    based on start_date and end_date. 'active' as True will return campaigns
+    where start_date <= now < end_date and 'active' as False will return campaigns
+    where now < start_date || now >= end_date."""
 
-    class Meta(object):
-        model = Campaign
-        fields = ("start_date", "end_date", )
+    def filter_queryset(self, request, queryset, view):
+
+        new_queryset = queryset
+
+        key_active = 'active'
+
+        now = datetime.now()
+        if key_active in request.QUERY_PARAMS:
+            val = request.QUERY_PARAMS[key_active].lower()
+            if val == 'true':
+                # start_date <= now < end_date
+                new_queryset = queryset.filter(
+                    start_date__lte=now,
+                    end_date__gt=now
+                )
+            elif val == 'false':
+                # now < start_date || now >= end_date
+                new_queryset = \
+                    queryset.filter(start_date__gt=now) | \
+                    new_queryset.filter(end_date__lte=now)
+
+        return new_queryset
 
 
 class CampaignViewSet(viewsets.ModelViewSet):
     queryset = Campaign.objects.all()
     serializer_class = CampaignSerializer
     paginate_by = 10
-    # filters
-    filter_backends = (filters.DjangoFilterBackend, filters.SearchFilter, filters.OrderingFilter, )
-    filter_class = CampaignFilter
-    # search
-    search_fields = ("campaign_label", "sponsor_name", )
-    # ordering
-    ordering_fields = ("campaign_label", "sponsor_name", "start_date", "end_date", )
+    filter_backends = (
+        CampaignActiveFilter,
+        filters.SearchFilter,
+        filters.OrderingFilter,)
+    search_fields = (
+        "campaign_label",
+        "sponsor_name",)
+    ordering_fields = (
+        "campaign_label",
+        "sponsor_name",
+        "start_date",
+        "end_date",)
     permission_classes = [IsAdminUser]
 
 

--- a/bulbs/special_coverage/api.py
+++ b/bulbs/special_coverage/api.py
@@ -23,6 +23,8 @@ class SpecialCoverageViewSet(viewsets.ModelViewSet):
     )
     ordering_fields = (
         "name",
+        "active",
+        "promoted",
         "campaign__campaign_label",
         "campaign__sponsor_name"
     )

--- a/bulbs/special_coverage/api.py
+++ b/bulbs/special_coverage/api.py
@@ -1,6 +1,8 @@
 from rest_framework import filters, routers, viewsets
 from rest_framework.permissions import IsAdminUser
 
+from bulbs.utils.filters import CaseInsensitiveBooleanFilter
+
 from .models import SpecialCoverage
 from .serializers import SpecialCoverageSerializer
 
@@ -8,8 +10,11 @@ from .serializers import SpecialCoverageSerializer
 class SpecialCoverageViewSet(viewsets.ModelViewSet):
     queryset = SpecialCoverage.objects.all()
     serializer_class = SpecialCoverageSerializer
-    filter_backends = (filters.SearchFilter, filters.OrderingFilter, filters.DjangoFilterBackend,)
-    filter_fields = ("active", "promoted")
+    filter_backends = (
+        CaseInsensitiveBooleanFilter,
+        filters.SearchFilter,
+        filters.OrderingFilter,)
+    boolean_fields = ("active", "promoted")
     search_fields = (
         "name",
         "description",

--- a/bulbs/utils/filters.py
+++ b/bulbs/utils/filters.py
@@ -17,10 +17,10 @@ class CaseInsensitiveBooleanFilter(filters.BaseFilterBackend):
         boolean_filters = {}
         for field in boolean_fields:
             if field in request.QUERY_PARAMS:
-                val = request.QUERY_PARAMS[field]
-                if val in ['true', 'True']:
+                val = request.QUERY_PARAMS[field].lower()
+                if val == 'true':
                     boolean_filters[field] = True
-                elif val in ['false', 'False']:
+                elif val == 'false':
                     boolean_filters[field] = False
 
         if len(boolean_filters) > 0:

--- a/bulbs/utils/filters.py
+++ b/bulbs/utils/filters.py
@@ -1,0 +1,29 @@
+from rest_framework import filters
+
+
+class CaseInsensitiveBooleanFilter(filters.BaseFilterBackend):
+    """Set a boolean_fields tuple on the viewset and set this class as a
+    filter_backend to filter listed fields through a case-insensitive transformation
+    to be used for filtering. i.e. query params such as 'true' become boolean
+    True, and params with a value 'false' become boolean False."""
+
+    def filter_queryset(self, request, queryset, view):
+
+        boolean_fields = getattr(view, 'boolean_fields', None)
+
+        if not boolean_fields:
+            return queryset
+
+        boolean_filters = {}
+        for field in boolean_fields:
+            if field in request.QUERY_PARAMS:
+                val = request.QUERY_PARAMS[field]
+                if val in ['true', 'True']:
+                    boolean_filters[field] = True
+                elif val in ['false', 'False']:
+                    boolean_filters[field] = False
+
+        if len(boolean_filters) > 0:
+            return queryset.filter(**boolean_filters)
+
+        return queryset

--- a/tests/special_coverage/test_spec_cov_api.py
+++ b/tests/special_coverage/test_spec_cov_api.py
@@ -279,6 +279,31 @@ class SpecialCoverageApiTestCase(BaseAPITestCase):
         """Test that special coverage search results can be ordered by their status."""
 
         special_coverage_1 = SpecialCoverage.objects.create(name="Promoted",
+                                                            active=False,
+                                                            promoted=False)
+        special_coverage_2 = SpecialCoverage.objects.create(name="Active but not promoted",
+                                                            active=False,
+                                                            promoted=True)
+        special_coverage_3 = SpecialCoverage.objects.create(name="Not active",
+                                                            active=True,
+                                                            promoted=False)
+        special_coverage_4 = SpecialCoverage.objects.create(name="Not really a valid state",
+                                                            active=True,
+                                                            promoted=True)
+
+        response = self.client.get(reverse("special-coverage-list"),
+                                   data={"ordering": "active,promoted"})
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data["results"][0]["id"], special_coverage_1.pk)
+        self.assertEqual(response.data["results"][1]["id"], special_coverage_2.pk)
+        self.assertEqual(response.data["results"][2]["id"], special_coverage_3.pk)
+        self.assertEqual(response.data["results"][3]["id"], special_coverage_4.pk)
+
+    def test_special_coverage_ordering_by_status_reverse(self):
+        """Test that special coverage search results can be ordered by their status
+        in reverse."""
+
+        special_coverage_1 = SpecialCoverage.objects.create(name="Promoted",
                                                             active=True,
                                                             promoted=True)
         special_coverage_2 = SpecialCoverage.objects.create(name="Active but not promoted",
@@ -286,13 +311,13 @@ class SpecialCoverageApiTestCase(BaseAPITestCase):
                                                             promoted=False)
         special_coverage_3 = SpecialCoverage.objects.create(name="Not active",
                                                             active=False,
-                                                            promoted=False)
+                                                            promoted=True)
         special_coverage_4 = SpecialCoverage.objects.create(name="Not really a valid state",
                                                             active=False,
-                                                            promoted=True)
+                                                            promoted=False)
 
         response = self.client.get(reverse("special-coverage-list"),
-                                   data={"ordering": "active,promoted"})
+                                   data={"ordering": "-active,-promoted"})
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.data["results"][0]["id"], special_coverage_1.pk)
         self.assertEqual(response.data["results"][1]["id"], special_coverage_2.pk)

--- a/tests/special_coverage/test_spec_cov_api.py
+++ b/tests/special_coverage/test_spec_cov_api.py
@@ -342,3 +342,25 @@ class SpecialCoverageApiTestCase(BaseAPITestCase):
         self.assertEqual(resp.data["slug"], special_coverage.slug)
         self.assertEqual(resp.data["description"], special_coverage.description)
         self.assertIsNone(resp.data["campaign"])
+
+    def test_active_and_promoted_lowercase_boolean(self):
+        """Tests that filter backend can correctly evaluate 'true' and 'false'."""
+
+        special_coverage_1 = SpecialCoverage.objects.create(name="Promoted",
+                                                            active=True,
+                                                            promoted=True)
+        special_coverage_2 = SpecialCoverage.objects.create(name="Not active or promoted",
+                                                            active=False,
+                                                            promoted=False)
+
+        response = self.client.get(reverse("special-coverage-list"),
+                                   data={"active": "true", "promoted": "true"})
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data["results"]), 1)
+        self.assertEqual(response.data["results"][0]["id"], special_coverage_1.pk)
+
+        response = self.client.get(reverse("special-coverage-list"),
+                                   data={"active": "false", "promoted": "false"})
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data["results"]), 1)
+        self.assertEqual(response.data["results"][0]["id"], special_coverage_2.pk)


### PR DESCRIPTION
**New**
- Added CaseInsensitiveBooleanFilter to allow boolean query parameters to be evaluated for filtering in a case-insensitive manner.
- Campaigns can be filtered by active and inactive.