### PR TITLE
Retrieve content via absolute URL lookup

### DIFF
--- a/bulbs/api/views.py
+++ b/bulbs/api/views.py
@@ -2,8 +2,10 @@
 
 from django.conf import settings
 from django.contrib.auth import get_user_model
+from django.core.urlresolvers import resolve, Resolver404
 from django.db.models.loading import get_models
 from django.http import Http404
+from django.shortcuts import get_object_or_404
 from django.utils import timezone
 from django.utils.dateparse import parse_datetime
 from djes.apps import indexable_registry
@@ -439,6 +441,21 @@ class ContentTypeViewSet(viewsets.ViewSet):
         return Response(dict(results=results))
 
 
+class ContentResolveViewSet(viewsets.ReadOnlyModelViewSet):
+    """Retrieve content corresponding to absolute URL"""
+    model = Content
+
+    def list(self, request):
+        if "url" in get_query_params(self.request):
+            try:
+                match = resolve(get_query_params(self.request).get("url"))
+            except Resolver404:
+                raise Http404("No content found matching UUID")
+
+            content = get_object_or_404(Content, pk=match.kwargs.get('pk'))
+            return Response(ContentSerializer().to_representation(content))
+
+
 class CustomSearchContentViewSet(viewsets.GenericViewSet):
     """This is for searching with a custom search filter."""
     model = Content
@@ -510,6 +527,7 @@ api_v1_router = routers.DefaultRouter()
 api_v1_router.register(r"content", ContentViewSet, base_name="content")
 api_v1_router.register(r"custom-search-content", CustomSearchContentViewSet, base_name="custom-search-content")
 api_v1_router.register(r"content-type", ContentTypeViewSet, base_name="content-type")
+api_v1_router.register(r"content-resolve", ContentResolveViewSet, base_name="content-resolve")
 api_v1_router.register(r"tag", TagViewSet, base_name="tag")
 api_v1_router.register(r"log", LogEntryViewSet, base_name="logentry")
 api_v1_router.register(r"author", AuthorViewSet, base_name="author")

--- a/bulbs/api/views.py
+++ b/bulbs/api/views.py
@@ -454,6 +454,8 @@ class ContentResolveViewSet(viewsets.ReadOnlyModelViewSet):
 
             content = get_object_or_404(Content, pk=match.kwargs.get('pk'))
             return Response(ContentSerializer().to_representation(content))
+        else:
+            raise Http404('Must specify content "url" param')
 
 
 class CustomSearchContentViewSet(viewsets.GenericViewSet):

--- a/bulbs/api/views.py
+++ b/bulbs/api/views.py
@@ -1,5 +1,10 @@
 """API Views and ViewSets"""
 
+try:
+    from urllib.parse import urlparse
+except ImportError:
+    from urlparse import urlparse
+
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.core.urlresolvers import resolve, Resolver404
@@ -446,9 +451,10 @@ class ContentResolveViewSet(viewsets.ReadOnlyModelViewSet):
     model = Content
 
     def list(self, request):
-        if "url" in get_query_params(self.request):
+        url = get_query_params(self.request).get("url")
+        if url:
             try:
-                match = resolve(get_query_params(self.request).get("url"))
+                match = resolve(urlparse(url).path)
             except Resolver404:
                 raise Http404("No content found matching UUID")
 

--- a/tests/api/test_content_api.py
+++ b/tests/api/test_content_api.py
@@ -581,3 +581,23 @@ class TestContentTypeSearchAPI(BaseAPITestCase):
         r = self.api_client.get(url, format="json")
         self.assertEqual(r.status_code, 200)
         self.assertEqual(len(r.data["results"]), 4)
+
+
+class TestContentResolveAPI(BaseAPITestCase):
+
+    def test_resolve_url(self):
+        make_content(id=123)
+        r = self.api_client.get(reverse("content-resolve-list"),
+                                dict(url="/r/123"), format="json")
+        self.assertEqual(r.status_code, 200)
+        self.assertEqual(123, r.data['id'])
+
+    def test_invalid_url(self):
+        r = self.api_client.get(reverse("content-resolve-list"),
+                                dict(url="/does_not_exist"))
+        self.assertEqual(r.status_code, 404)
+
+    def test_not_found(self):
+        r = self.api_client.get(reverse("content-resolve-list"),
+                                dict(url="/r/1"))
+        self.assertEqual(r.status_code, 404)

--- a/tests/api/test_content_api.py
+++ b/tests/api/test_content_api.py
@@ -3,14 +3,22 @@ from datetime import datetime, timedelta
 
 import elasticsearch
 from django.contrib.auth import get_user_model
+from django.conf.urls import patterns, url
 from django.core.urlresolvers import reverse
 from django.template.defaultfilters import slugify
 from django.test.client import Client
+from django.test.utils import override_settings
 from django.utils import timezone
 
+import bulbs.api.urls
 from bulbs.content.models import LogEntry, Tag, Content, ObfuscatedUrlInfo
 from example.testcontent.models import TestContentObj, TestContentDetailImage
 from bulbs.utils.test import JsonEncoder, BaseAPITestCase, make_content
+
+try:
+    from unittest.mock import Mock
+except ImportError:
+    from mock import Mock
 
 
 class TestContentListingAPI(BaseAPITestCase):
@@ -583,25 +591,48 @@ class TestContentTypeSearchAPI(BaseAPITestCase):
         self.assertEqual(len(r.data["results"]), 4)
 
 
+
 class TestContentResolveAPI(BaseAPITestCase):
 
-    def test_resolve_url(self):
+    def resolve(self, **data):
+        return self.api_client.get(reverse("content-resolve-list"),
+                                   data=data, format="json")
+
+    def test_resolve_redirect_url(self):
         make_content(id=123)
-        r = self.api_client.get(reverse("content-resolve-list"),
-                                dict(url="/r/123"), format="json")
-        self.assertEqual(r.status_code, 200)
-        self.assertEqual(123, r.data['id'])
+        for url in ('http://test.local/r/123',
+                    '/r/123tsd',
+                    '/r/123?one=two&three=four',
+                    'http://test.local/r/123',
+                    'http://test.local/r/123?one=two'):
+            r = self.resolve(url=url)
+            self.assertEqual(r.status_code, 200)
+            self.assertEqual(123, r.data['id'])
+
+    def test_resolve_custom_content_url(self):
+        # Simulate app-specific content URL
+        class ContentUrls(object):
+            urlpatterns = (bulbs.api.urls.urlpatterns +
+                           (url(r"^article/(?P<slug>[\w-]*)-(?P<pk>\d+)$", Mock()),))
+        make_content(id=123)
+        with override_settings(ROOT_URLCONF=ContentUrls):
+            r = self.resolve(url="/article/some-slug-123?one=two")
+            self.assertEqual(r.status_code, 200)
+            self.assertEqual(123, r.data['id'])
+
+    def test_resolve_custom_content_url_missing_pk(self):
+        # Simulate app-specific content URL
+        class ContentUrls(object):
+            urlpatterns = (bulbs.api.urls.urlpatterns +
+                           (url(r"^article/(?P<slug>[\w-]*)$", Mock()),))
+        with override_settings(ROOT_URLCONF=ContentUrls):
+            self.assertEqual(404, self.resolve(url="/article/some-slug").status_code)
 
     def test_invalid_url(self):
-        r = self.api_client.get(reverse("content-resolve-list"),
-                                dict(url="/does_not_exist"))
-        self.assertEqual(r.status_code, 404)
+        self.assertEqual(404, self.resolve(url="/does_not_exist").status_code)
 
     def test_not_found(self):
-        r = self.api_client.get(reverse("content-resolve-list"),
-                                dict(url="/r/1"))
-        self.assertEqual(r.status_code, 404)
+        self.assertEqual(404, self.resolve(url="/r/1").status_code)
 
     def test_missing_param(self):
-        r = self.api_client.get(reverse("content-resolve-list"))
-        self.assertEqual(r.status_code, 404)
+        self.assertEqual(404, self.resolve().status_code)

--- a/tests/api/test_content_api.py
+++ b/tests/api/test_content_api.py
@@ -601,3 +601,7 @@ class TestContentResolveAPI(BaseAPITestCase):
         r = self.api_client.get(reverse("content-resolve-list"),
                                 dict(url="/r/1"))
         self.assertEqual(r.status_code, 404)
+
+    def test_missing_param(self):
+        r = self.api_client.get(reverse("content-resolve-list"))
+        self.assertEqual(r.status_code, 404)


### PR DESCRIPTION
@MichaelButkovic  - This works, but I'm a REST novice, so please advise. 

- Using the list method to return a single object (which seems weird) 
- Passing the URL by query param seems cleaner than including it as part of the url path, since it will contain backslashes. 

A separate endpoint seemed like a cleaner approach, after exploring adding a filter to existing Content endpoint. 