### PR TITLE
Celery is now a regular (non-dev) requirement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,18 +2,18 @@
 
 ## Development
 
-- Campaign.save() triggers SpecialCoverage._save_percolator() via Celery task
+- Campaign.save() triggers `SpecialCoverage._save_percolator()` via Celery task
+- Install: Celery is now a regular (non-dev) requirement
+- Bump min DJES dependency to reflect latest requirements
 
 ## Version 0.7.1
 
-- Fix Content.percoloate_special_coverage() to ignore non-special-coverage results (ex: Sections)
-- Fix Content.percoloate_special_coverage() to filter out enries without start_date fields (prevents search failure if
-  one entry in shard was missing field)
+- Fix `Content.percoloate_special_coverage()` to ignore non-special-coverage results (ex: Sections)
+- Fix `Content.percoloate_special_coverage()` to filter out entries without `start_date` fields (prevents search failure if one entry in shard was missing field)
 
 ## Version 0.7.0
 
-- Added `Content.percolate_special_coverage()` containing new Special Coverage ordering rules to be shared by all client
-  sites
+- Added `Content.percolate_special_coverage()` containing new Special Coverage ordering rules to be shared by all client sites
 - Fixed `SpecialCoverage._save_percolator()` to *always* save to percolator. This fixes regression in **0.6.49** with switch from `active` boolean flag to `is_active` property based on start/end dates, which would cause inclusion in percolator based on when SpecialCoverage was last saved. This fix requires percolator retrieval to filter active Special Coverage by start/end dates, and is the reason for the breaking minor version change. Easiest to just use the new `Content.percolate_special_coverage()` method instead of site-specific queries.
 
 ## Version 0.6.43

--- a/bulbs/content/models.py
+++ b/bulbs/content/models.py
@@ -20,19 +20,10 @@ from polymorphic import PolymorphicModel, PolymorphicManager
 from djbetty import ImageField
 
 from bulbs.content import TagCache
+from bulbs.content.tasks import (index_content_contributions,
+                                 index_content_report_content_proxy)
 from .filters import Authors, Published, Status, Tags, FeatureTypes
 
-try:
-    from bulbs.content.tasks import (
-        index_content_contributions, index_content_report_content_proxy,
-        index as index_task
-    )  # noqa
-    CELERY_ENABLED = True
-except ImportError:
-    index_task = lambda *x: x
-    index_content_contributions = lambda *x: x
-    index_content_report_content_proxy = lambda *x: x
-    CELERY_ENABLED = False
 
 
 logger = logging.getLogger(__name__)

--- a/setup.py
+++ b/setup.py
@@ -15,11 +15,12 @@ author = "Chris Sinchok"
 author_email = "csinchok@theonion.com"
 license = "BSD"
 requires = [
+    "celery==3.1.10",
     "Django>=1.8,<1.9",
     "django-betty-cropper>=0.2.0",
     "djangorestframework==3.1.1",
     "django-polymorphic==0.7.1",
-    "djes>=0.1.7",
+    "djes>=0.1.105",
     "django-filter==0.9.2",
     "django-json-field==0.5.5",
     "djangorestframework-csv==1.3.3",
@@ -41,7 +42,6 @@ dev_requires = [
     "pytest==2.7.3",
     "pytest-cov==1.8.1",
     "pytest-django==2.8.0",
-    "celery==3.1.10",
     "coveralls==0.4.1",
     "freezegun"
 ]


### PR DESCRIPTION
Also cleanup unnecessary (and broken) task import error handler. This is a relic of a lost, magical time we'll never see again.

@benghaziboy as discussed (and updated DJES requirements to avoid breaking tests)

 @MichaelButkovic join the celery party