### PR TITLE
Fix flaky evergreen test

### DIFF
--- a/tests/content/test_content_manager.py
+++ b/tests/content/test_content_manager.py
@@ -5,7 +5,7 @@ from bulbs.campaigns.models import Campaign
 from bulbs.content.models import Content
 from bulbs.utils.test import make_content, BaseIndexableTestCase
 
-from example.testcontent.models import TestContentObj, TestContentObjTwo
+from example.testcontent.models import TestContentObj, TestContentObjTwo, TestReadingListObj
 
 
 class ContentManagerTestCase(BaseIndexableTestCase):

--- a/tests/content/test_content_manager.py
+++ b/tests/content/test_content_manager.py
@@ -17,7 +17,7 @@ class ContentManagerTestCase(BaseIndexableTestCase):
             start_date=timezone.now() - timezone.timedelta(days=5),
             end_date=timezone.now() + timezone.timedelta(days=5)
         )
-        make_content(evergreen=True, published=timezone.now(), _quantity=50)
+        make_content(TestReadingListObj, evergreen=True, published=timezone.now(), _quantity=50)
         make_content(TestContentObj, campaign=campaign, published=timezone.now(), _quantity=50)
         Content.search_objects.refresh()
 


### PR DESCRIPTION
If `make_content()` is not provided a content class type, it randomly chooses one, so every so often it was choosing the WRONG one, which caused inflated query results.

Recommend requiring explicit class type param for `make_content()`

@benghaziboy 