### PR TITLE
content_tunic_campaign_url tags

### DIFF
--- a/bulbs/content/templatetags/content.py
+++ b/bulbs/content/templatetags/content.py
@@ -1,0 +1,14 @@
+from django import template
+from django.conf import settings
+
+
+register = template.Library()
+
+
+@register.simple_tag
+def content_tunic_campaign_url(campaign_id):
+    return "{}{}/{}/public".format(
+        settings.TUNIC_BACKEND_ROOT,
+        settings.TUNIC_API_PATH,
+        campaign_id
+    )

--- a/tests/content/test_content_templatetags.py
+++ b/tests/content/test_content_templatetags.py
@@ -1,0 +1,37 @@
+from django.template import Context, Template, TemplateSyntaxError
+from django.test import override_settings
+
+from bulbs.utils.test import BaseIndexableTestCase
+
+
+TEST_TUNIC_BACKEND_ROOT = "//my.tunic.url"
+TEST_TUNIC_API_PATH = "/api/path/"
+
+
+class ContentTemplateTagsTestCase(BaseIndexableTestCase):
+
+    def setUp(self):
+        super(ContentTemplateTagsTestCase, self).setUp()
+
+    @override_settings(
+        TUNIC_BACKEND_ROOT=TEST_TUNIC_BACKEND_ROOT,
+        TUNIC_API_PATH=TEST_TUNIC_API_PATH,
+    )
+    def test_content_tunic_campaign_url(self):
+        """Test how template renders with an id."""
+
+        campaign_id = 1
+
+        t = Template("{{% load content %}}{{% content_tunic_campaign_url {} %}}".format(campaign_id))
+        c = Context({})
+        self.assertEquals(t.render(c), "{}{}/{}/public".format(
+            TEST_TUNIC_BACKEND_ROOT,
+            TEST_TUNIC_API_PATH,
+            campaign_id
+        ))
+
+    def test_content_tunic_campaign_url_no_id(self):
+        """Template should error out if no id was given."""
+
+        with self.assertRaises(TemplateSyntaxError):
+            Template("{% load content %}{% content_tunic_campaign_url %}")

--- a/tests/content/test_content_templatetags.py
+++ b/tests/content/test_content_templatetags.py
@@ -10,9 +10,6 @@ TEST_TUNIC_API_PATH = "/api/path/"
 
 class ContentTemplateTagsTestCase(BaseIndexableTestCase):
 
-    def setUp(self):
-        super(ContentTemplateTagsTestCase, self).setUp()
-
     @override_settings(
         TUNIC_BACKEND_ROOT=TEST_TUNIC_BACKEND_ROOT,
         TUNIC_API_PATH=TEST_TUNIC_API_PATH,


### PR DESCRIPTION
Adds `content_tunic_campaign_url` tag for rendering out env-specific tunic campaign urls.

@benghaziboy @MichaelButkovic @mparent61 @daytonn 