### PR TITLE
Wrapped footer in block so it can be overridden

### DIFF
--- a/bulbs/instant_articles/templates/instant_article/base_instant_article.html
+++ b/bulbs/instant_articles/templates/instant_article/base_instant_article.html
@@ -49,11 +49,13 @@
          <iframe src="http://{{ absolute_uri }}{% url 'instant_article_analytics' pk=content.id %}?platform=ia&path={{ content.get_absolute_url }}"></iframe>
       </figure>
 
+      {% block article_footer %}
       <footer>
         <small>
            &copy; Copyright {% now "Y" %} Onion Inc. All rights reserved
         </small>
       </footer>
+      {% endblock article_footer %}
     </article>
   </body>
 </html>


### PR DESCRIPTION
@mparent61 Simple change to wrap the `<footer>` in the base IA template in a block so the age disclaimer can be added by The Onion in its override