### PR TITLE
infographic metadata expensive choice query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Development
 
+## Version 3.1.1
+
+- Updated InfographicMetadata to exclude expensive `RelatedField` `ManyRelated` choice queries.
+
 ## Version 3.1.0
 
 - Added `AbstractInfographic` model to refer to all infographic specific attributes.

--- a/bulbs/infographics/metadata.py
+++ b/bulbs/infographics/metadata.py
@@ -1,11 +1,14 @@
 from collections import OrderedDict
 
+from django.utils.encoding import force_text
+
 from rest_framework import serializers
 from rest_framework.metadata import SimpleMetadata
 from rest_framework.utils.field_mapping import ClassLookupDict
 
 from djbetty.serializers import ImageFieldSerializer
 
+from bulbs.content.serializers import AuthorField
 from .data_serializers import CopySerializer, EntrySerializer, XYEntrySerializer
 from .fields import ColorField, RichTextField
 from .serializers import InfographicSerializer, InfographicDataField
@@ -20,12 +23,11 @@ def get_and_check_attribute(obj, attr_name):
 
 class InfographicMetadata(SimpleMetadata):
 
-    additional_attributes = ["field_size"]
-
     @property
     def label_lookup(self):
         mapping = SimpleMetadata.label_lookup.mapping
         mapping.update({
+            AuthorField: "string",
             ColorField: "color",
             CopySerializer: "array",
             EntrySerializer: "array",
@@ -42,12 +44,42 @@ class InfographicMetadata(SimpleMetadata):
             return data
         return super(InfographicMetadata, self).determine_metadata(request, view)
 
+    def get_label_lookup(self, field):
+        field_type = self.label_lookup[field]
+        if field_type == "field" and hasattr(field, "child_relation"):
+            return self.get_label_lookup(field.child_relation)
+        return field_type
+
     def get_field_info(self, field):
-        field_info = super(InfographicMetadata, self).get_field_info(field)
-        for attr in self.additional_attributes:
-            meta = getattr(field, attr, None)
-            if meta:
-                field_info.update({attr: meta})
+        field_info = OrderedDict()
+        field_info["type"] = self.get_label_lookup(field)
+        field_info["required"] = getattr(field, "required", False)
+
+        attrs = [
+            "field_size", "read_only", "label", "help_text", "min_length", "max_length",
+            "min_value", "max_value"
+        ]
+
+        for attr in attrs:
+            value = getattr(field, attr, None)
+            if value is not None and value != "":
+                field_info[attr] = force_text(value, strings_only=True)
+
+        if getattr(field, "child", None):
+            field_info["child"] = self.get_field_info(field.child)
+        elif getattr(field, "fields", None):
+            field_info["children"] = self.get_serializer_info(field)
+
+        if (not isinstance(field, (serializers.RelatedField, serializers.ManyRelatedField)) and
+                hasattr(field, "choices")):
+            field_info["choices"] = [
+                {
+                    "value": choice_value,
+                    "display_name": force_text(choice_name, strings_only=True)
+                }
+                for choice_value, choice_name in field.choices.items()
+            ]
+
         return field_info
 
     def get_serializer_info(self, serializer):

--- a/bulbs/infographics/metadata.py
+++ b/bulbs/infographics/metadata.py
@@ -51,6 +51,14 @@ class InfographicMetadata(SimpleMetadata):
         return field_type
 
     def get_field_info(self, field):
+        """
+        This method is basically a mirror from rest_framework==3.3.3
+
+        We are currently pinned to rest_framework==3.1.1. If we upgrade,
+        this can be refactored and simplified to rely more heavily on
+        rest_framework's built in logic.
+        """
+
         field_info = OrderedDict()
         field_info["type"] = self.get_label_lookup(field)
         field_info["required"] = getattr(field, "required", False)

--- a/tests/infographics/test_api.py
+++ b/tests/infographics/test_api.py
@@ -99,17 +99,17 @@ class BaseInfographicTestCase(BaseAPITestCase):
                         OrderedDict([
                             ("type", "richtext"),
                             ("required", True),
+                            ("field_size", "long"),
                             ("read_only", False),
-                            ("label", "Copy"),
-                            ("field_size", "long")
+                            ("label", "Copy")
                         ]),
                     ), (
                         "title", OrderedDict([
                             ("type", "richtext"),
                             ("required", True),
+                            ("field_size", "short"),
                             ("read_only", False),
                             ("label", "Title"),
-                            ("field_size", "short")
                         ]),
                     ), (
                         "image", OrderedDict([
@@ -142,16 +142,16 @@ class BaseInfographicTestCase(BaseAPITestCase):
                         "copy", OrderedDict([
                             ("type", "richtext"),
                             ("required", True),
+                            ("field_size", "long"),
                             ("read_only", False),
                             ("label", "Copy"),
-                            ("field_size", "long")
                         ])), (
                         "title", OrderedDict([
                             ("type", "richtext"),
                             ("required", True),
+                            ("field_size", "short"),
                             ("read_only", False),
                             ("label", "Title"),
-                            ("field_size", "short")
                         ])), (
                         "image", OrderedDict([
                             ("type", "image"),
@@ -180,8 +180,8 @@ class BaseInfographicTestCase(BaseAPITestCase):
                 "body": OrderedDict([
                     ("type", "richtext"),
                     ("required", True),
+                    ("field_size", "long"),
                     ("read_only", False),
-                    ("field_size", "long")
                 ]),
                 "strong": OrderedDict([
                     ("type", "array"),
@@ -189,9 +189,9 @@ class BaseInfographicTestCase(BaseAPITestCase):
                         "copy", OrderedDict([
                             ("type", "richtext"),
                             ("required", True),
+                            ("field_size", "long"),
                             ("read_only", False),
                             ("label", "Copy"),
-                            ("field_size", "long")
                         ]))
                     ]))
                 ]),
@@ -201,9 +201,9 @@ class BaseInfographicTestCase(BaseAPITestCase):
                         "copy", OrderedDict([
                             ("type", "richtext"),
                             ("required", True),
+                            ("field_size", "long"),
                             ("read_only", False),
                             ("label", "Copy"),
-                            ("field_size", "long")
                         ]))
                     ]))
                 ]),
@@ -226,8 +226,9 @@ class BaseInfographicTestCase(BaseAPITestCase):
                 "body": OrderedDict([
                     ("type", "richtext"),
                     ("required", True),
-                    ("read_only", False),
-                    ("field_size", "long")
+                    ("field_size", "long"),
+                    ("read_only", False)
+
                 ]),
                 "con": OrderedDict([
                     ("type", "array"),
@@ -235,9 +236,10 @@ class BaseInfographicTestCase(BaseAPITestCase):
                         ("copy", OrderedDict([
                             ("type", "richtext"),
                             ("required", True),
+                            ("field_size", "long"),
                             ("read_only", False),
                             ("label", "Copy"),
-                            ("field_size", "long")
+
                         ]))
                     ]))
                 ]),
@@ -247,9 +249,9 @@ class BaseInfographicTestCase(BaseAPITestCase):
                         ("copy", OrderedDict([
                             ("type", "richtext"),
                             ("required", True),
+                            ("field_size", "long"),
                             ("read_only", False),
                             ("label", "Copy"),
-                            ("field_size", "long")
                         ]))
                     ]))
                 ])
@@ -276,25 +278,25 @@ class BaseInfographicTestCase(BaseAPITestCase):
                             "title", OrderedDict([
                                 ("type", "richtext"),
                                 ("required", True),
+                                ("field_size", "short"),
                                 ("read_only", False),
                                 ("label", "Title"),
-                                ("field_size", "short")
                             ])
                         ), (
                             "copy_x", OrderedDict([
                                 ("type", "richtext"),
                                 ("required", True),
+                                ("field_size", "long"),
                                 ("read_only", False),
                                 ("label", "Copy x"),
-                                ("field_size", "long")
                             ])
                         ), (
                             "copy_y", OrderedDict([
                                 ("type", "richtext"),
                                 ("required", True),
+                                ("field_size", "long"),
                                 ("read_only", False),
                                 ("label", "Copy y"),
-                                ("field_size", "long")
                             ])
                         )
                     ]))
@@ -304,9 +306,9 @@ class BaseInfographicTestCase(BaseAPITestCase):
                         "title", OrderedDict([
                             ("type", "richtext"),
                             ("required", True),
+                            ("field_size", "short"),
                             ("read_only", False),
                             ("label", "Title"),
-                            ("field_size", "short")
                         ])
                     ), (
                         "color", OrderedDict([
@@ -329,9 +331,9 @@ class BaseInfographicTestCase(BaseAPITestCase):
                         "title", OrderedDict([
                             ("type", "richtext"),
                             ("required", True),
+                            ("field_size", "short"),
                             ("read_only", False),
-                            ("label", "Title"),
-                            ("field_size", "short")
+                            ("label", "Title")
                         ])
                     ), (
                         "color", OrderedDict([


### PR DESCRIPTION
@mparent61 @MichaelButkovic 

this deals with queryset choices being an expensive query in our actual environments while not being useful., This is what I was referring to as being fixed in `rest_framework>=3.3`, but that route is also more complicated.