### PR TITLE
Fix Cam's broken test scripts

### DIFF
--- a/scripts/init_db
+++ b/scripts/init_db
@@ -11,23 +11,5 @@ docker-compose run \
     -e PGUSER=postgres \
     -e PGPASSWORD=${PGPASSWORD} \
     web \
-    psql -c "CREATE ROLE ${SITE_ID} PASSWORD '${SITE_PASSWORD}' SUPERUSER LOGIN CREATEDB;" \
+    psql -c "CREATE ROLE bulbs PASSWORD 'testing' SUPERUSER LOGIN CREATEDB;" \
     || true
-
-docker-compose run \
-    -e PGHOST=postgres \
-    -e PGUSER=${SITE_ID} \
-    -e PGPASSWORD=${SITE_PASSWORD} \
-    web \
-    psql -d postgres -c "DROP DATABASE IF EXISTS ${SITE_DB};"
-
-docker-compose run \
-    -e PGHOST=postgres \
-    -e PGUSER=${SITE_ID} \
-    -e PGPASSWORD=${SITE_PASSWORD} \
-    web \
-    psql -d postgres -c "CREATE DATABASE ${SITE_DB};"
-
-docker-compose run \
-    web \
-    python manage.py migrate --noinput

--- a/scripts/test
+++ b/scripts/test
@@ -3,4 +3,4 @@
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 
-docker-compose run web py.test tests/
+docker-compose run web py.test "$@"


### PR DESCRIPTION
- [x] `init_db` properly sets up `bulbs` database role
- [x] `scripts/test` passes arguments through to `py.test`