### PR TITLE
SF: relations endpoint ordering 

### DIFF
--- a/bulbs/super_features/views.py
+++ b/bulbs/super_features/views.py
@@ -18,7 +18,7 @@ class RelationViewSet(views.APIView):
     permission_classes = (IsAdminUser, CanEditContent,)
 
     def get(self, request, pk):
-        children = SUPERFEATURE_MODEL.objects.filter(parent__id=pk)
+        children = SUPERFEATURE_MODEL.objects.filter(parent__id=pk).order_by("ordering")
         result = SUPERFEATURE_PARTIAL_SERIALIZER(children, many=True)
 
         return Response(result.data, status=status.HTTP_200_OK)

--- a/tests/super_features/test_views.py
+++ b/tests/super_features/test_views.py
@@ -49,6 +49,63 @@ class SuperFeatureViewsTestCase(BaseAPITestCase):
             ])
         ])
 
+    def test_parent_get_children_correct_ordering(self):
+        # create new children
+        child2 = BaseSuperFeature.objects.create(
+            title="Guide to Bats",
+            notes="This is the guide to bats",
+            superfeature_type=GUIDE_TO_ENTRY,
+            parent=self.parent,
+            ordering=2,
+            data={
+                "entries": [{
+                    "title": "bats",
+                    "copy": "Everybody loves bats"
+                }]
+            }
+        )
+        child3 = BaseSuperFeature.objects.create(
+            title="Guide to Bats",
+            notes="This is the guide to bats",
+            superfeature_type=GUIDE_TO_ENTRY,
+            parent=self.parent,
+            ordering=3,
+            data={
+                "entries": [{
+                    "title": "bats",
+                    "copy": "Everybody loves bats"
+                }]
+            }
+        )
+
+        # switch up order
+        url = reverse('super-feature-relations-ordering', kwargs={'pk': self.parent.pk})
+        data = [
+            {
+                "id": child3.id,
+                "ordering": 1
+            },
+            {
+                "id": self.child.id,
+                "ordering": 2
+            },
+            {
+                "id": child2.id,
+                "ordering": 3
+            }
+        ]
+        resp = self.api_client.put(url, data, format="json")
+        self.assertEqual(resp.status_code, 200)
+
+        # test that the order is correct
+        url = reverse('super-feature-relations', kwargs={'pk': self.parent.pk})
+        resp = self.api_client.get(url)
+
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.data[0]['id'], child3.id)
+        self.assertEqual(resp.data[1]['id'], self.child.id)
+        self.assertEqual(resp.data[2]['id'], child2.id)
+
     def test_parent_set_child_dates(self):
         url = reverse('super-feature-set-children-dates', kwargs={'pk': self.parent.pk})
         resp = self.api_client.put(url)


### PR DESCRIPTION
@kand @mparent61 @benghaziboy this is to guarantee that relations endpoint ordering is correct 