### PR TITLE
add data-track-action to share tools, needed for click tracking

### DIFF
--- a/bulbs/homepage_player/templates/homepage_player/bulbs_homepage_player.html
+++ b/bulbs/homepage_player/templates/homepage_player/bulbs_homepage_player.html
@@ -30,6 +30,7 @@
       </bulbs-video-meta>
       <share-tools
           class="video-carousel-share-tools {{ share_style }}"
+          data-track-action="HP: Main: Share"
           share-title="{{ videos.0.videohub_ref.title }}"
           share-url={% build_video_share_uri videos.0.videohub_ref.id %}
           share-track-action="HP: Main: Share">


### PR DESCRIPTION
Click tracking isn't working on the homepage player, because `data-track-action` is required. 